### PR TITLE
Use div function from stdlib.h

### DIFF
--- a/LodeRunner_Render.ino
+++ b/LodeRunner_Render.ino
@@ -664,8 +664,10 @@ void renderScoreboard() {
 
     uint8_t levelNumber = level.getLevelNumber();
     arduboy.drawCompressedMirror(96, 58, level_sc, WHITE, false);
-    Sprites::drawOverwrite(113, 58, numbers, levelNumber / 100);
-    levelNumber = levelNumber - (levelNumber / 100) * 100;
+    
+    const auto divT = div(levelNumber, 100);
+    Sprites::drawOverwrite(113, 58, numbers, divT.quot);
+    levelNumber = divT.rem;
     Sprites::drawOverwrite(118, 58, numbers, levelNumber / 10);
     Sprites::drawOverwrite(123, 58, numbers, levelNumber % 10);
 


### PR DESCRIPTION
Saves 6 bytes of progmem.
See http://en.cppreference.com/w/cpp/numeric/math/div for more information about `div`.
Essentially it's a fusion of both `/` and `%`.
Unfortunately there's no variant smaller than `int` so this is the only case in `renderScoreboard` where it will produce a size saving.